### PR TITLE
ajustando o corte na tela definição de senha

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -45,7 +45,7 @@
  </style>
 
 </head>
-<nav class="navbar navbar-expand-lg bg-dark text-white fixed-top" data-bs-theme="dark">
+<nav class="navbar navbar-expand-lg bg-dark text-white sticky-top" data-bs-theme="dark">
   <div class="container-fluid text-white">
     <a class="navbar-brand" href="#">AjudaTche!</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
@@ -125,7 +125,7 @@
 </nav>
 
 <body class="bg-light">
-  <div class="container">
+  <div class="container pt-2">
     {% for message in app.flashes('success') %}
       <br>
       <br>


### PR DESCRIPTION
a position fixed da navbar fazia com que o texto da pagina de redefinição de senha ficasse cortada, portanto alterei a position para sticky e o padding do container para dar um espaçamento.